### PR TITLE
Update README with 'yarn install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Basic project structure for a Polymer 3 app written in Typescript
 
+## Prepare
+
+`$ yarn install`
+
 ## Run in development mode
 
 `$ yarn start`


### PR DESCRIPTION
Just add a part in the README to make explicit the need to run `yarn install` before `yarn start` or `yarn build` for whose are not familiar with yarn or npm.